### PR TITLE
Added directory/wildcard support

### DIFF
--- a/squeezeit/__init__.py
+++ b/squeezeit/__init__.py
@@ -145,12 +145,23 @@ def loadfiles(configfile, config, srcdir, files):
 	
 	for file in files:
 		try:
+			if '*' in file:
+				file, suffix = file.split('*')
 			filepath = os.path.join(srcdir,file)
-			f = open(filepath)
-			filedata = f.read()
-			f.close()
-			
-			rawdata.append(filedata)
+			if os.path.isdir(filepath):
+				for (dirpath,dirnames,filenames) in os.walk(filepath):
+					for filename in filenames:
+						if suffix and not filename.endswith(suffix):
+							continue
+						f = open(os.path.join(dirpath,filename))
+						filedata = f.read()
+						f.close()
+						rawdata.append(filedata)
+			else:
+				f = open(filepath)
+				filedata = f.read()
+				f.close()
+				rawdata.append(filedata)
 		except:
 			logging.warning("Could not read {0}". format(filepath))
 	


### PR DESCRIPTION
I've added support for directories with an optional file suffix. In other words the following paths are now supported:

```
- /foo/bar
- /foo/bar/*.js
```

In the first case if bar is a dir, all files in bar and its subfolders will be loaded. In the second case only the files ending in ".js" will be added.

It's a bit incomplete in that there's no way to add only files directly contained in the folder itself (and not its subfolders) and the wildcard doesn't allow prefixes. I would have used glob, except I can't find a way to make glob also search in subfolders and I favoured the more inclusive approach because this was born out of the need of having deep hierarchies of JS files that I don't want to have to keep track of in Squeezeit.
