### PR TITLE
Added semicolons in JS concatenation

### DIFF
--- a/squeezeit/__init__.py
+++ b/squeezeit/__init__.py
@@ -224,7 +224,7 @@ def processbundle(configfile, config, bundlename, bundledata):
 	if bundledata['includes']['javascript']:
 		logging.info('-Processing Javascript')
 		rawdata = loadfiles(configfile, config, config['javascript'], bundledata['includes']['javascript'])
-		rawdata = ''.join(rawdata)
+		rawdata = '\n;'.join(rawdata)
 		
 		#Some info
 		md5 = hashlib.md5(rawdata).hexdigest()

--- a/squeezeit/__init__.py
+++ b/squeezeit/__init__.py
@@ -165,7 +165,7 @@ def loadfiles(configfile, config, srcdir, files):
 		except:
 			logging.warning("Could not read {0}". format(filepath))
 	
-	return ''.join(rawdata)
+	return rawdata
 
 def writedata(configfile, config, output, filename, rawdata):
 	"""Write the file data to the output directory"""
@@ -224,6 +224,7 @@ def processbundle(configfile, config, bundlename, bundledata):
 	if bundledata['includes']['javascript']:
 		logging.info('-Processing Javascript')
 		rawdata = loadfiles(configfile, config, config['javascript'], bundledata['includes']['javascript'])
+		rawdata = ''.join(rawdata)
 		
 		#Some info
 		md5 = hashlib.md5(rawdata).hexdigest()
@@ -266,6 +267,7 @@ def processbundle(configfile, config, bundlename, bundledata):
 	if bundledata['includes']['css']:
 		logging.info('-Processing CSS')
 		rawdata = loadfiles(configfile, config, config['css'], bundledata['includes']['css'])
+		rawdata = ''.join(rawdata)
 
 		#Some info
 		md5 = hashlib.md5(rawdata).hexdigest()


### PR DESCRIPTION
I kept on running into issues with JS files that do not end with a trailing semicolon followed by files that begin with an open parenthesis.

To resolve this within Squeezeit I've removed the concatenation from the generic load function and added it to the JS/CSS specific code. This means the load function now returns a list containing the loaded file contents rather than a single concatenated string.

There is probably a better way to do this, but this at least prevents concatenation-induced syntax errors.
